### PR TITLE
Livewire filter

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -66,7 +66,7 @@ class ProjectController extends Controller
         ]);
 
         if($request->tags) {
-            $project->syncTags(explode(',',str_replace(' ', '', $request->tags)));
+            $project->tags()->sync($request->tags);
         }
 
         if($request->hasFile('files')) {
@@ -132,7 +132,7 @@ class ProjectController extends Controller
         ]);
 
         if ($request->tags) {
-            $project->syncTags(explode(',', str_replace(' ', '', $request->tags)));
+            $project->tags()->sync($request->tags);
         }
 
         if ($request->hasFile('files')) {

--- a/app/Http/Livewire/Projects/ProjectsIndex.php
+++ b/app/Http/Livewire/Projects/ProjectsIndex.php
@@ -9,11 +9,14 @@ class ProjectsIndex extends Component
 {
     public $projects;
     public $filterType;
+    public $filterTags = [];
 
-    public function updatedFilterType()
+    public function updated()
     {
         $this->projects = Project::when($this->filterType, function($query){
             return $query->where('type_id', $this->filterType);
+        })->when($this->filterTags, function($query) {
+            return $query->withAnyTags($this->filterTags);
         })->get();
     }
 

--- a/app/Http/Livewire/Projects/ProjectsIndex.php
+++ b/app/Http/Livewire/Projects/ProjectsIndex.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Livewire\Projects;
+
+use App\Models\Project;
+use Livewire\Component;
+
+class ProjectsIndex extends Component
+{
+    public $projects;
+    public $filter;
+
+    public function updatedFilter()
+    {
+        $this->projects = Project::when($this->filter, function($query){
+            return $query->where('type_id', $this->filter);
+        })->get();
+    }
+
+    public function render()
+    {
+        return view('livewire.projects.projects-index');
+    }
+}

--- a/app/Http/Livewire/Projects/ProjectsIndex.php
+++ b/app/Http/Livewire/Projects/ProjectsIndex.php
@@ -8,12 +8,12 @@ use Livewire\Component;
 class ProjectsIndex extends Component
 {
     public $projects;
-    public $filter;
+    public $filterType;
 
-    public function updatedFilter()
+    public function updatedFilterType()
     {
-        $this->projects = Project::when($this->filter, function($query){
-            return $query->where('type_id', $this->filter);
+        $this->projects = Project::when($this->filterType, function($query){
+            return $query->where('type_id', $this->filterType);
         })->get();
     }
 

--- a/app/Http/Livewire/Projects/TagsInput.php
+++ b/app/Http/Livewire/Projects/TagsInput.php
@@ -3,9 +3,27 @@
 namespace App\Http\Livewire\Projects;
 
 use Livewire\Component;
+use Spatie\Tags\Tag;
 
 class TagsInput extends Component
 {
+    public $projectTags = [];
+
+    public function mount($project = [])
+    {
+        if ($project) {
+            $this->projectTags = $this->formatTags($project->tags);
+        }
+        $this->allTags = $this->formatTags(Tag::all());
+    }
+    
+    public function formatTags($tags)
+    {
+        return $tags->map(function ($tag) {
+            return ['id' => $tag->id, 'text' => $tag->name];
+        })->toArray();
+    }
+    
     public function render()
     {
         return view('livewire.projects.tags-input');

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -8,6 +8,7 @@ use App\Models\ProjectType;
 use Illuminate\Database\Seeder;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\Models\Permission;
+use Spatie\Tags\Tag;
 
 
 class DatabaseSeeder extends Seeder
@@ -38,6 +39,26 @@ class DatabaseSeeder extends Seeder
 
         ProjectType::create([
             'name' => 'Overig'
+        ]);
+        
+        Tag::create([
+            'name' => 'Frontend'
+        ]);
+
+        Tag::create([
+            'name' => 'Backend'
+        ]);
+
+        Tag::create([
+            'name' => 'HTML'
+        ]);
+
+        Tag::create([
+            'name' => 'PHP'
+        ]);
+
+        Tag::create([
+            'name' => 'C#'
         ]);
 
         if (!Role::where('name', 'admin')->first()) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,13 @@
 {
-    "name": "projectbureau-fedd",
+    "name": "projectbureau",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "jquery": "^3.6.3",
+                "select2": "^4.1.0-rc.0"
+            },
             "devDependencies": {
                 "@tailwindcss/forms": "^0.5.2",
                 "alpinejs": "^3.4.2",
@@ -976,6 +980,11 @@
                 "node": ">=0.12.0"
             }
         },
+        "node_modules/jquery": {
+            "version": "3.6.3",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
+            "integrity": "sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg=="
+        },
         "node_modules/laravel-vite-plugin": {
             "version": "0.7.1",
             "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-0.7.1.tgz",
@@ -1395,6 +1404,11 @@
             "dependencies": {
                 "queue-microtask": "^1.2.2"
             }
+        },
+        "node_modules/select2": {
+            "version": "4.1.0-rc.0",
+            "resolved": "https://registry.npmjs.org/select2/-/select2-4.1.0-rc.0.tgz",
+            "integrity": "sha512-Hr9TdhyHCZUtwznEH2CBf7967mEM0idtJ5nMtjvk3Up5tPukOLXbHUNmh10oRfeNIhj+3GD3niu+g6sVK+gK0A=="
         },
         "node_modules/source-map-js": {
             "version": "1.0.2",
@@ -2166,6 +2180,11 @@
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true
         },
+        "jquery": {
+            "version": "3.6.3",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
+            "integrity": "sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg=="
+        },
         "laravel-vite-plugin": {
             "version": "0.7.1",
             "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-0.7.1.tgz",
@@ -2420,6 +2439,11 @@
             "requires": {
                 "queue-microtask": "^1.2.2"
             }
+        },
+        "select2": {
+            "version": "4.1.0-rc.0",
+            "resolved": "https://registry.npmjs.org/select2/-/select2-4.1.0-rc.0.tgz",
+            "integrity": "sha512-Hr9TdhyHCZUtwznEH2CBf7967mEM0idtJ5nMtjvk3Up5tPukOLXbHUNmh10oRfeNIhj+3GD3niu+g6sVK+gK0A=="
         },
         "source-map-js": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -14,5 +14,9 @@
         "postcss": "^8.4.6",
         "tailwindcss": "^3.1.0",
         "vite": "^3.0.0"
+    },
+    "dependencies": {
+        "jquery": "^3.6.3",
+        "select2": "^4.1.0-rc.0"
     }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,4 @@
+@import 'select2/dist/css/select2.min.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -10,6 +10,12 @@ window._ = _;
 import axios from 'axios';
 window.axios = axios;
 
+import jQuery from 'jquery';
+window.$ = jQuery;
+
+import select2 from 'select2';
+window.select2 = select2();
+
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
 /**

--- a/resources/views/components/checkbox.blade.php
+++ b/resources/views/components/checkbox.blade.php
@@ -1,0 +1,4 @@
+<div class="flex items-center mr-4">
+    <input type="checkbox" {{$attributes->merge(['class' => 'w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 focus:ring-2'])}}>
+    <label for="{{$id ?? ''}}" class="ml-2 text-sm font-medium text-gray-900">{{$slot}}</label>
+</div>

--- a/resources/views/livewire/projects/projects-index.blade.php
+++ b/resources/views/livewire/projects/projects-index.blade.php
@@ -15,7 +15,7 @@
 			<x-checkbox id="PHP" value="PHP" name="filterTags[]" wire:model="filterTags">
 				PHP
 			</x-checkbox>
-			<x-checkbox id="C#" value="c#" name="filterTags[]" wire:model="filterTags">
+			<x-checkbox id="C#" value="C#" name="filterTags[]" wire:model="filterTags">
 				C#
 			</x-checkbox>
 		</div>

--- a/resources/views/livewire/projects/projects-index.blade.php
+++ b/resources/views/livewire/projects/projects-index.blade.php
@@ -1,0 +1,24 @@
+<div class="">
+	<div class="p-4 flex justify-between items-center content-start">
+		<h2 class="my-2 border-bottom-2 text-2xl"> Lopende projecten </h2>
+
+		<select wire:model="filter" id="type" class="w-fit bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 pr-7">
+			<option value="">Filteren op type</option>
+			@foreach(\App\Models\ProjectType::all() as $type)
+				<option value="{{ $type->id }}">{{ $type->name }}</option>
+			@endforeach
+		</select>
+
+		<a href="{{ route('projects.create') }}"
+		   class=" bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">+ Nieuw project
+		</a>
+	</div>
+
+	<div class="grid grid-cols-3 gap-3">
+		@forelse($projects as $project)
+			<x-project-card :project="$project"/>
+		@empty
+			<p>nog geen projecten</p>
+		@endforelse
+	</div>
+</div>

--- a/resources/views/livewire/projects/projects-index.blade.php
+++ b/resources/views/livewire/projects/projects-index.blade.php
@@ -3,10 +3,10 @@
 		<h2 class="my-2 border-bottom-2 text-2xl"> Lopende projecten </h2>
 
 		<div class="flex">
-			<x-checkbox id="frontend" value="frontend" name="filterTags[]" wire:model="filterTags">
+			<x-checkbox id="frontend" value="Frontend" name="filterTags[]" wire:model="filterTags">
 				Frontend
 			</x-checkbox>
-			<x-checkbox id="backend" value="backend" name="filterTags[]" wire:model="filterTags">
+			<x-checkbox id="backend" value="Backend" name="filterTags[]" wire:model="filterTags">
 				Backend
 			</x-checkbox>
 			<x-checkbox id="HTML" value="HTML" name="filterTags[]" wire:model="filterTags">

--- a/resources/views/livewire/projects/projects-index.blade.php
+++ b/resources/views/livewire/projects/projects-index.blade.php
@@ -2,6 +2,24 @@
 	<div class="p-4 flex justify-between items-center content-start">
 		<h2 class="my-2 border-bottom-2 text-2xl"> Lopende projecten </h2>
 
+		<div class="flex">
+			<x-checkbox id="frontend" value="frontend" name="filterTags[]" wire:model="filterTags">
+				Frontend
+			</x-checkbox>
+			<x-checkbox id="backend" value="backend" name="filterTags[]" wire:model="filterTags">
+				Backend
+			</x-checkbox>
+			<x-checkbox id="HTML" value="HTML" name="filterTags[]" wire:model="filterTags">
+				HTML
+			</x-checkbox>
+			<x-checkbox id="PHP" value="PHP" name="filterTags[]" wire:model="filterTags">
+				PHP
+			</x-checkbox>
+			<x-checkbox id="C#" value="c#" name="filterTags[]" wire:model="filterTags">
+				C#
+			</x-checkbox>
+		</div>
+		
 		<select wire:model="filterType" id="type" class="w-fit bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5 pr-7">
 			<option value="">Filteren op type</option>
 			@foreach(\App\Models\ProjectType::all() as $type)

--- a/resources/views/livewire/projects/projects-index.blade.php
+++ b/resources/views/livewire/projects/projects-index.blade.php
@@ -2,7 +2,7 @@
 	<div class="p-4 flex justify-between items-center content-start">
 		<h2 class="my-2 border-bottom-2 text-2xl"> Lopende projecten </h2>
 
-		<select wire:model="filter" id="type" class="w-fit bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 pr-7">
+		<select wire:model="filterType" id="type" class="w-fit bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5 pr-7">
 			<option value="">Filteren op type</option>
 			@foreach(\App\Models\ProjectType::all() as $type)
 				<option value="{{ $type->id }}">{{ $type->name }}</option>

--- a/resources/views/livewire/projects/tags-input.blade.php
+++ b/resources/views/livewire/projects/tags-input.blade.php
@@ -1,10 +1,33 @@
 <div class="mb-4">
-    @if(isset($project))
-     <i>Labels: @foreach($project->tags as $tab)
-                    <span class="bg-blue-100 text-blue-800 text-xs font-semibold mr-2 px-2.5 py-0.5 rounded dark:bg-blue-200 dark:text-blue-800">{{$badge->name}}</span>
-                @endforeach
-     </i>
-    @endif
-    <label for="">Tags (zonder hashtag, gescheiden door komma's)</label>
-    <input type="text" placeholder="html, php, javascript" name="tags" id="tags"  class="bg-gray-100 border-2 w-full p-4 rounded-lg">
+	@if(isset($project))
+		<i>Labels: @foreach($project->tags as $tab)
+				<span class="bg-blue-100 text-blue-800 text-xs font-semibold mr-2 px-2.5 py-0.5 rounded dark:bg-blue-200 dark:text-blue-800">{{$badge->name}}</span>
+			@endforeach
+		</i>
+	@endif
+	<label for="">Tags (gekozen uit dropdown)</label>
+	<select id="tag-input" name="tags[]" class="border-2 w-full p-4 rounded-lg" multiple></select>
 </div>
+
+@push('scripts')
+	<script type="module">
+		$( document ).ready( function () {
+			let projectTags = {!! json_encode($projectTags) ?? [] !!};
+			let formattedTags = projectTags.map( ( tag ) => {
+				return tag.id || tag;
+			} );
+
+			$( "#tag-input" ).select2( {
+				tags: true,
+				tokenSeparators: [ ',' ],
+				theme: 'classic',
+				placeholder: 'HTML, PHP, JavaScript',
+				createTag: function ( params ) {
+					return undefined;
+				},
+				data: {!! json_encode($allTags) !!},
+			} )
+				.val( formattedTags ).trigger( 'change' );
+		} );
+	</script>
+@endpush

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -137,4 +137,6 @@
             </div>
         </div>
     </div>
+    
+    @stack('scripts')
 </x-app-layout>

--- a/resources/views/projects/edit.blade.php
+++ b/resources/views/projects/edit.blade.php
@@ -125,14 +125,8 @@
 
                         <div class="mb-4">
                             @if(isset($project))
-                             <i>Gegeven Tags: @foreach($project->tags as $tab)
-                                            <span class="bg-blue-100 text-blue-800 text-xs font-semibold mr-2 px-2.5 py-0.5 rounded dark:bg-blue-200 dark:text-blue-800">{{$tab->name}}</span>
-                                        @endforeach
-                             </i>
+                                @livewire('projects.tags-input', ['project' => $project])
                             @endif
-                            <br>
-                            <label for="">Tags (zonder hashtag, gescheiden door komma's)</label>
-                            <input type="text" placeholder="html, php, javascript" name="tags" id="tags"  class="bg-gray-100 border-2 w-full p-4 rounded-lg">
                         </div>
 
                         <p class="text-lg text-gray-400 font-bold mb-2">Bijlagen</p>
@@ -157,4 +151,5 @@
             </div>
         </div>
     </div>
+    @stack('scripts')
 </x-app-layout>

--- a/resources/views/projects/index.blade.php
+++ b/resources/views/projects/index.blade.php
@@ -6,24 +6,10 @@
     </x-slot>
 
     <div class="py-12">
-         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 bg-white border-b border-gray-200">
-                    <div class="">
-                        {{-- add create button --}}
-                        <div class="p-4 flex justify-between content-start" >
-                            <h2 class="my-2 border-bottom-2 text-2xl"> Lopende projecten </h2>
-                            <a href="{{ route('projects.create') }}" class=" bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">+ Nieuw project</a>
-                        </div>
-
-                        <div class="grid grid-cols-3 gap-3">
-                        @forelse($projects as $project)
-                            <x-project-card :project="$project" />
-                        @empty
-                            <p>nog geen projecten</p>
-                        @endforelse
-                        </div>
-                    </div>
+                    @livewire('projects.projects-index', ['projects' => $projects])
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fixes #18 

Added filters for projects and new way of adding tags to projects.

When creating a project, you can now only use tags from the database (not add your own). The tags are created in the seeder.

I have not changed the styling of the Select2 input, because I heard the other team is working on a new website theme (#10). When they start implementing a new design, they can style the input to fit in with the rest of the form/page.